### PR TITLE
Add wrapper option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ This string will be prepended to the beginning of the concatenated output. It is
 
 _(Default processing options are explained in the [grunt.template.process][] documentation)_
 
+#### wrapper
+Type: `Array`  
+Default: empty array
+
+The first element of this array will be prepended to every file and the second element will be appended to every file that is processed. Before that the content is processed using [grunt.template.process][].
+
 #### stripBanners
 Type: `Boolean` `Object`  
 Default: `false`

--- a/tasks/concat.js
+++ b/tasks/concat.js
@@ -19,7 +19,8 @@ module.exports = function(grunt) {
       separator: grunt.util.linefeed,
       banner: '',
       stripBanners: false,
-      process: false
+      process: false,
+      wrapper: []
     });
 
     // Normalize boolean options that accept options objects.
@@ -28,6 +29,11 @@ module.exports = function(grunt) {
 
     // Process banner.
     var banner = grunt.template.process(options.banner);
+
+    // Process wrapper
+    if (options.wrapper.length === 2) {
+      var wrapper = [grunt.template.process(options.wrapper[0]), grunt.template.process(options.wrapper[1])];
+    }
 
     // Iterate over all src-dest file pairs.
     this.files.forEach(function(f) {
@@ -50,6 +56,10 @@ module.exports = function(grunt) {
         // Strip banners if requested.
         if (options.stripBanners) {
           src = comment.stripBanner(src, options.stripBanners);
+        }
+        // Add wrapper if defined
+        if (wrapper) {
+          src = wrapper[0] + src + wrapper[1];
         }
         return src;
       }).join(grunt.util.normalizelf(options.separator));


### PR DESCRIPTION
This option allows for the concatenated files to be wrapped, like in grunt-wrap. For example:

``` js
// file_a
return 'A';
```

``` js
// file_b
return 'B';
```

``` js
// excerpt Gruntfile.js
concat: {
  build: {
    src: ['file_a.js', 'file_b.js'],
    dest: 'concat.js'
    options: {
      wrapper: ['module.exports = function() { \n', '\n};']
     }
  }
}
```

Result:

``` js
module.exports = function() {
// file_a
return 'A';
};
module.exports = function() {
// file_b
return 'B';
};
```
