### PR TITLE
Add footer option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ This string will be prepended to the beginning of the concatenated output. It is
 
 _(Default processing options are explained in the [grunt.template.process][] documentation)_
 
+#### footer
+Type: `String`  
+Default: empty string
+
+This string will be appended to the end of the concatenated output. It is processed using [grunt.template.process][], using the default options.
+
+_(Default processing options are explained in the [grunt.template.process][] documentation)_
+
 #### stripBanners
 Type: `Boolean` `Object`  
 Default: `false`
@@ -112,6 +120,26 @@ grunt.initConfig({
     dist: {
       src: ['src/project.js'],
       dest: 'dist/built.js'
+    }
+  }
+});
+```
+
+#### Wrap the output
+
+In this example, we can concatenate our script files and the output will be wraped in an if-statement, writing the output to `dist/myApp.js`. This can be useful in case you don't want to process the script if it's allready loaded and initialized.
+
+```js
+// Project configuration.
+grunt.initConfig({
+  concat: {
+    options: {
+      banner: "if(typeof myApp === 'undefined'){",
+      footer: "}"
+    },
+    dist: {
+      src: ['src/myApp.js', 'src/myApp.UI.js', 'src/myApp.data.js'],
+      dest: 'dist/myApp.js'
     }
   }
 });

--- a/tasks/concat.js
+++ b/tasks/concat.js
@@ -18,6 +18,7 @@ module.exports = function(grunt) {
     var options = this.options({
       separator: grunt.util.linefeed,
       banner: '',
+      footer: '',
       stripBanners: false,
       process: false
     });
@@ -26,12 +27,13 @@ module.exports = function(grunt) {
     if (options.stripBanners === true) { options.stripBanners = {}; }
     if (options.process === true) { options.process = {}; }
 
-    // Process banner.
+    // Process banner and footer.
     var banner = grunt.template.process(options.banner);
+    var footer = grunt.template.process(options.footer);
 
     // Iterate over all src-dest file pairs.
     this.files.forEach(function(f) {
-      // Concat banner + specified files.
+      // Concat banner + specified files + footer.
       var src = banner + f.src.filter(function(filepath) {
         // Warn on and remove invalid source files (if nonull was set).
         if (!grunt.file.exists(filepath)) {
@@ -52,7 +54,7 @@ module.exports = function(grunt) {
           src = comment.stripBanner(src, options.stripBanners);
         }
         return src;
-      }).join(grunt.util.normalizelf(options.separator));
+      }).join(grunt.util.normalizelf(options.separator)) + footer;
 
       // Write the destination file.
       grunt.file.write(f.dest, src);


### PR DESCRIPTION
Apart from the banner option, it's useful to have a footer option
that can be used in order to wrap concatenated output in a block.

This is not the same case to this one: https://github.com/gruntjs/grunt-contrib-concat/pull/9/

In the previous version of grunt we used to have the same effect with an other trick that doesn't work now. Take a look here:
https://github.com/cbotsikas/Webinos-Platform/blob/master/grunt.js#L33
Lines: 33, 41, 72
