### PR TITLE
Allow strings to be concatenated along with files

### DIFF
--- a/tasks/concat.js
+++ b/tasks/concat.js
@@ -33,18 +33,10 @@ module.exports = function(grunt) {
 
     // Iterate over all src-dest file pairs.
     this.files.forEach(function(f) {
-      // Concat banner + specified files + footer.
-      var src = banner + f.src.filter(function(filepath) {
-        // Warn on and remove invalid source files (if nonull was set).
-        if (!grunt.file.exists(filepath)) {
-          grunt.log.warn('Source file "' + filepath + '" not found.');
-          return false;
-        } else {
-          return true;
-        }
-      }).map(function(filepath) {
-        // Read file source.
-        var src = grunt.file.read(filepath);
+      // Concat banner + specified files/strings + footer.
+      var src = banner + f.orig.src.map(function(filepath) {
+        // Read file source, or use as a string if file doesn't exist.
+        var src = grunt.file.exists(filepath) ? grunt.file.read(filepath) : filepath;
         // Process files as templates if requested.
         if (options.process) {
           src = grunt.template.process(src, options.process);

--- a/test/expected/handling_invalid_files
+++ b/test/expected/handling_invalid_files
@@ -1,2 +1,3 @@
 file1
+invalid_file/should_warn/but_not_fail
 file2


### PR DESCRIPTION
I needed to be able to concatenate (dynamic) strings as well as files. Opening a pull request in case it's helpful for anyone.
### Example usage:

**Gruntfile.js**

```
concat: {
  example: {
    files: {
      'my.txt': [
        'here is a string',
        'middle.txt',
        'here is another string'
      ],
    }
  }
}
```

**middle.txt**

```
this is the middle text file
```

**my.txt**

```
here is a string
this is the middle text file
here is another string
```
