### PR TITLE
Concat does not process banner and footer

### DIFF
--- a/tasks/concat.js
+++ b/tasks/concat.js
@@ -28,8 +28,9 @@ module.exports = function(grunt) {
     if (options.process === true) { options.process = {}; }
 
     // Process banner and footer.
-    var banner = grunt.template.process(options.banner);
-    var footer = grunt.template.process(options.footer);
+    var templateLocals = options.process && options.process.data;
+    var banner = grunt.template.process(options.banner, templateLocals);
+    var footer = grunt.template.process(options.footer, templateLocals);
 
     // Iterate over all src-dest file pairs.
     this.files.forEach(function(f) {
@@ -63,5 +64,4 @@ module.exports = function(grunt) {
       grunt.log.writeln('File "' + f.dest + '" created.');
     });
   });
-
 };


### PR DESCRIPTION
The docs say that banner and footer are processed as templates before concatenation, but HEAD does not pass the concat's default options through when processing the banner and footer.

This pull adds the options to both calls to process in the style of the implementation.

I looked at testing this, but the current test suite and implementation make this hard without significant refactoring. I'm happy to suggest implementations in a subsequent pull request if you like.
