### PR TITLE
Fix StripBanners option for concat

### DIFF
--- a/tasks/concat.js
+++ b/tasks/concat.js
@@ -24,8 +24,8 @@ module.exports = function(grunt) {
     });
 
     // Normalize boolean options that accept options objects.
-    if (options.stripBanners === true) { options.stripBanners = {}; }
-    if (options.process === true) { options.process = {}; }
+    if (typeof options.stripBanners === 'boolean' && options.stripBanners === true) { options.stripBanners = {}; }
+    if (typeof options.process === 'boolean' && options.process === true) { options.process = {}; }
 
     // Process banner and footer.
     var banner = grunt.template.process(options.banner);

--- a/tasks/lib/comment.js
+++ b/tasks/lib/comment.js
@@ -13,21 +13,24 @@ exports.init = function(/*grunt*/) {
 
   // Return the given source cude with any leading banner comment stripped.
   exports.stripBanner = function(src, options) {
-    if (!options) { options = {}; }
-    var m = [];
-    if (options.line) {
-      // Strip // ... leading banners.
-      m.push('(?:.*\\/\\/.*\\n)*\\s*');
-    }
-    if (options.block) {
-      // Strips all /* ... */ block comment banners.
-      m.push('\\/\\*[\\s\\S]*?\\*\\/');
-    } else {
-      // Strips only /* ... */ block comment banners, excluding /*! ... */.
-      m.push('\\/\\*[^!][\\s\\S]*?\\*\\/');
-    }
-    var re = new RegExp('^\\s*(?:' + m.join('|') + ')\\s*', '');
-    return src.replace(re, '');
+      if (!options) { options = {}; }
+      var m = [];
+      if (options.line) {
+          // Strip // ... leading banners.
+          m.push('(/{2,}[\\s\\S].*)');
+      }
+      if (options.block) {
+          // Strips all /* ... */ block comment banners.
+          m.push('(\/+\\*+[\\s\\S]*?\\*\\/+)');
+      } else {
+          // Strips only /* ... */ block comment banners, excluding /*! ... */.
+          m.push('(\/+\\*+[^!][\\s\\S]*?\\*\\/+)');
+
+      }
+      var re = new RegExp('\s*(' + m.join('|') + ')\s*', 'g');
+      src = src.replace(re, '');
+      src = src.replace(/\s{2,}(\r|\n|\s){2,}$/gm, '');
+      return src;
   };
 
   return exports;


### PR DESCRIPTION
StripBanners now work when passing in object (e.g. {block: true, line:
true}).
