### PR TITLE
Proper hierarchy for the footer option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This string will be prepended to the beginning of the concatenated output. It is
 
 _(Default processing options are explained in the [grunt.template.process][] documentation)_
 
-###### footer
+#### footer
 Type: `String`
 Default: empty string
 

--- a/docs/concat-options.md
+++ b/docs/concat-options.md
@@ -14,7 +14,7 @@ This string will be prepended to the beginning of the concatenated output. It is
 
 _(Default processing options are explained in the [grunt.template.process][] documentation)_
 
-#### footer
+## footer
 Type: `String`
 Default: empty string
 


### PR DESCRIPTION
It's a trivial thing, but I've just had to look at the source of `concat.js` to find the footer option. This was _after_ reading the readme, and concluding this option didn't exist!

Why did I miss it? The hierarchy previously given to this option made it look as if footer was somehow a property of banner, when they really are **sibling options** from the end user's POV.
