### PR TITLE
Add option to process files with a custom function

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
 "Cowboy" Ben Alman (http://benalman.com/)
 Tyler Kellen (http://goingslowly.com/)
+Dan Wolff (http://danwolff.se/)

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -51,6 +51,17 @@ module.exports = function(grunt) {
         dest: 'tmp/handling_invalid_files',
         nonull: true,
       },
+      process_function: {
+        options: {
+          process: function(src, filepath) {
+            return '// Source: ' + filepath + '\n' +
+              src.replace(/file(\d)/, 'f$1');
+          }
+        },
+        files: {
+          'tmp/process_function': ['test/fixtures/file1', 'test/fixtures/file2']
+        }
+      },
     },
 
     // Unit tests.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Process source files as [templates][] before concatenating.
 * `false` - No processing will occur.
 * `true` - Process source files using [grunt.template.process][] defaults.
 * `options` object - Process source files using [grunt.template.process][], using the specified options.
+* `function(src, filepath)` - Process source files using the given function, called once for each file. The returned value will be used as source code.
 
 _(Default processing options are explained in the [grunt.template.process][] documentation)_
 
@@ -233,18 +234,41 @@ grunt.initConfig({
 See [configuring files for a task](http://gruntjs.com/configuring-tasks#files) for how to configure file globbing in Grunt.
 
 
+#### Custom process function
+If you would like to do any custom processing before concatenating, use a custom process function:
+
+```js
+runt.initConfig({
+  concat: {
+    dist: {
+      options: {
+        // Replace all 'use strict' statements in the code with a single one at the top
+        banner: "'use strict';\n",
+        process: function(src, filepath) {
+          return '// Source: ' + filepath + '\n' +
+            src.replace(/(^|\n)[ \t]*('use strict'|"use strict");?\s*/g, '$1');
+        },
+      },
+      files: {
+        'dist/built.js': ['src/project.js'],
+      },
+    },
+  },
+});
+```
+
 ## Release History
 
- * 2013-04-07   v0.2.0   Dont normalize separator to allow user to set LF even on a Windows environment.
- * 2013-02-21   v0.1.3   Support footer option.
- * 2013-02-14   v0.1.2   First official release for Grunt 0.4.0.
- * 2013-01-17   v0.1.2rc6   Updating grunt/gruntplugin dependencies to rc6. Changing in-development grunt/gruntplugin dependency versions from tilde version ranges to specific versions.
- * 2013-01-08   v0.1.2rc5   Updating to work with grunt v0.4.0rc5. Switching back to this.files api.
- * 2012-11-12   v0.1.1   Switch to this.file api internally.
- * 2012-10-02   v0.1.0   Work in progress, not yet officially released.
+ * 2013-04-08   v0.2.0   Dont normalize separator to allow user to set LF even on a Windows environment.
+ * 2013-02-22   v0.1.3   Support footer option.
+ * 2013-02-15   v0.1.2   First official release for Grunt 0.4.0.
+ * 2013-01-18   v0.1.2rc6   Updating grunt/gruntplugin dependencies to rc6. Changing in-development grunt/gruntplugin dependency versions from tilde version ranges to specific versions.
+ * 2013-01-09   v0.1.2rc5   Updating to work with grunt v0.4.0rc5. Switching back to this.files api.
+ * 2012-11-13   v0.1.1   Switch to this.file api internally.
+ * 2012-10-03   v0.1.0   Work in progress, not yet officially released.
 
 ---
 
 Task submitted by ["Cowboy" Ben Alman](http://benalman.com/)
 
-*This file was generated on Mon Apr 08 2013 10:12:23.*
+*This file was generated on Sun Apr 14 2013 16:21:52.*

--- a/docs/concat-examples.md
+++ b/docs/concat-examples.md
@@ -151,3 +151,27 @@ grunt.initConfig({
 ```
 
 See [configuring files for a task](http://gruntjs.com/configuring-tasks#files) for how to configure file globbing in Grunt.
+
+
+## Custom process function
+If you would like to do any custom processing before concatenating, use a custom process function:
+
+```js
+runt.initConfig({
+  concat: {
+    dist: {
+      options: {
+        // Replace all 'use strict' statements in the code with a single one at the top
+        banner: "'use strict';\n",
+        process: function(src, filepath) {
+          return '// Source: ' + filepath + '\n' +
+            src.replace(/(^|\n)[ \t]*('use strict'|"use strict");?\s*/g, '$1');
+        },
+      },
+      files: {
+        'dist/built.js': ['src/project.js'],
+      },
+    },
+  },
+});
+```

--- a/docs/concat-options.md
+++ b/docs/concat-options.md
@@ -44,6 +44,7 @@ Process source files as [templates][] before concatenating.
 * `false` - No processing will occur.
 * `true` - Process source files using [grunt.template.process][] defaults.
 * `options` object - Process source files using [grunt.template.process][], using the specified options.
+* `function(src, filepath)` - Process source files using the given function, called once for each file. The returned value will be used as source code.
 
 _(Default processing options are explained in the [grunt.template.process][] documentation)_
 

--- a/tasks/concat.js
+++ b/tasks/concat.js
@@ -46,7 +46,9 @@ module.exports = function(grunt) {
         // Read file source.
         var src = grunt.file.read(filepath);
         // Process files as templates if requested.
-        if (options.process) {
+        if (typeof options.process === 'function') {
+          src = options.process(src, filepath);
+        } else if (options.process) {
           src = grunt.template.process(src, options.process);
         }
         // Strip banners if requested.

--- a/test/concat_test.js
+++ b/test/concat_test.js
@@ -51,5 +51,14 @@ exports.concat = {
     test.equal(comment.stripBanner(src, {block: true}), grunt.util.normalizelf('\n// This is\n// A sample\n// Banner\n\n// But this is not\n\n/* And neither\n * is this\n */\n'), 'It should not strip the top banner.');
     test.equal(comment.stripBanner(src, {line: true}), grunt.util.normalizelf('// But this is not\n\n/* And neither\n * is this\n */\n'), 'It should strip the top banner.');
     test.done();
+  },
+  process_function: function(test) {
+    test.expect(1);
+
+    var actual = getNormalizedFile('tmp/process_function');
+    var expected = getNormalizedFile('test/expected/process_function');
+    test.equal(actual, expected, 'should have processed file content.');
+
+    test.done();
   }
 };

--- a/test/expected/process_function
+++ b/test/expected/process_function
@@ -1,0 +1,4 @@
+// Source: test/fixtures/file1
+f1
+// Source: test/fixtures/file2
+f2


### PR DESCRIPTION
The `process` option can now take a function which will be called once for each file. The returned value will be used as the source code.

Here's my use case:

``` js
// Replace all 'use strict' statements in the code with a single one at the top:
runt.initConfig({
  concat: {
    dist: {
      options: {
        banner: "'use strict';\n",
        process: function(src, filepath) {
          return '// Source: ' + filepath + '\n' +
            src.replace(/(^|\n)[ \t]*('use strict'|"use strict");?\s*/g, '$1');
        },
      },
      files: { ... },
    },
  },
});
```
