### PR TITLE
Normalize code examples, clarify and fix typos in the documentation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,7 +5,7 @@ v0.3.0:
 v0.2.0:
   date: 2013-04-08
   changes:
-    - Dont normalize separator to allow user to set LF even on a Windows environment.
+    - Don't normalize separator to allow user to set LF even on a Windows environment.
 v0.1.3:
   date: 2013-02-22
   changes:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ grunt.loadNpmTasks('grunt-contrib-concat');
 ## Concat task
 _Run this task with the `grunt concat` command._
 
-Task targets, files and options may be specified according to the grunt [Configuring tasks](http://gruntjs.com/configuring-tasks) guide.
+Task targets, files and options may be specified according to the Grunt [Configuring tasks](http://gruntjs.com/configuring-tasks) guide.
+
 ### Options
 
 #### separator
@@ -64,10 +65,10 @@ Strip JavaScript banner comments from source files.
   * `line` - If true, any contiguous _leading_ `//` line comments are stripped.
 
 #### process
-Type: `Boolean` `Object`
+Type: `Boolean` `Object` `Function`
 Default: `false`
 
-Process source files as [templates][] before concatenating.
+Process source files before concatenating, either as [templates][] or with a custom function.
 
 * `false` - No processing will occur.
 * `true` - Process source files using [grunt.template.process][] defaults.
@@ -77,7 +78,7 @@ Process source files as [templates][] before concatenating.
 _(Default processing options are explained in the [grunt.template.process][] documentation)_
 
   [templates]: https://github.com/gruntjs/grunt/wiki/grunt.template
-  [grunt.template.process]: https://github.com/gruntjs/grunt/wiki/grunt.template#wiki-grunt-template-process
+  [grunt.template.process]: https://github.com/gruntjs/grunt/wiki/grunt.template#grunttemplateprocess
 
 ### Usage Examples
 
@@ -90,13 +91,13 @@ In this example, running `grunt concat:dist` (or `grunt concat` because `concat`
 grunt.initConfig({
   concat: {
     options: {
-      separator: ';'
+      separator: ';',
     },
     dist: {
       src: ['src/intro.js', 'src/project.js', 'src/outro.js'],
-      dest: 'dist/built.js'
-    }
-  }
+      dest: 'dist/built.js',
+    },
+  },
 });
 ```
 
@@ -116,13 +117,13 @@ grunt.initConfig({
     options: {
       stripBanners: true,
       banner: '/*! <%= pkg.name %> - v<%= pkg.version %> - ' +
-        '<%= grunt.template.today("yyyy-mm-dd") %> */'
+        '<%= grunt.template.today("yyyy-mm-dd") %> */',
     },
     dist: {
       src: ['src/project.js'],
-      dest: 'dist/built.js'
-    }
-  }
+      dest: 'dist/built.js',
+    },
+  },
 });
 ```
 
@@ -138,13 +139,13 @@ grunt.initConfig({
   concat: {
     basic: {
       src: ['src/main.js'],
-      dest: 'dist/basic.js'
+      dest: 'dist/basic.js',
     },
     extras: {
       src: ['src/main.js', 'src/extras.js'],
-      dest: 'dist/with_extras.js'
-    }
-  }
+      dest: 'dist/with_extras.js',
+    },
+  },
 });
 ```
 
@@ -163,10 +164,10 @@ grunt.initConfig({
     basic_and_extras: {
       files: {
         'dist/basic.js': ['src/main.js'],
-        'dist/with_extras.js': ['src/main.js', 'src/extras.js']
-      }
-    }
-  }
+        'dist/with_extras.js': ['src/main.js', 'src/extras.js'],
+      },
+    },
+  },
 });
 ```
 
@@ -183,9 +184,9 @@ grunt.initConfig({
   concat: {
     dist: {
       src: ['src/main.js'],
-      dest: 'dist/<%= pkg.name %>-<%= pkg.version %>.js'
-    }
-  }
+      dest: 'dist/<%= pkg.name %>-<%= pkg.version %>.js',
+    },
+  },
 });
 ```
 
@@ -195,24 +196,24 @@ In this more involved example, running `grunt concat` will build two separate fi
 
 For example, if the `package.json` file contained `{"name": "awesome", "version": "1.0.0"}`, the files `dist/awesome/1.0.0/basic.js` and `dist/awesome/1.0.0/with_extras.js` would be generated.
 
-```javascript
+```js
 // Project configuration.
 grunt.initConfig({
   pkg: grunt.file.readJSON('package.json'),
   dirs: {
     src: 'src/files',
-    dest: 'dist/<%= pkg.name %>/<%= pkg.version %>'
+    dest: 'dist/<%= pkg.name %>/<%= pkg.version %>',
   },
   concat: {
     basic: {
       src: ['<%= dirs.src %>/main.js'],
-      dest: '<%= dirs.dest %>/basic.js'
+      dest: '<%= dirs.dest %>/basic.js',
     },
     extras: {
       src: ['<%= dirs.src %>/main.js', '<%= dirs.src %>/extras.js'],
-      dest: '<%= dirs.dest %>/with_extras.js'
-    }
-  }
+      dest: '<%= dirs.dest %>/with_extras.js',
+    },
+  },
 });
 ```
 
@@ -238,7 +239,7 @@ See [configuring files for a task](http://gruntjs.com/configuring-tasks#files) f
 If you would like to do any custom processing before concatenating, use a custom process function:
 
 ```js
-runt.initConfig({
+grunt.initConfig({
   concat: {
     dist: {
       options: {
@@ -257,10 +258,13 @@ runt.initConfig({
 });
 ```
 
+  [multi task]: https://github.com/gruntjs/grunt/wiki/grunt.task#grunttaskregistermultitask-
+
+
 ## Release History
 
  * 2013-04-25   v0.3.0   Add option to process files with a custom function.
- * 2013-04-08   v0.2.0   Dont normalize separator to allow user to set LF even on a Windows environment.
+ * 2013-04-08   v0.2.0   Don't normalize separator to allow user to set LF even on a Windows environment.
  * 2013-02-22   v0.1.3   Support footer option.
  * 2013-02-15   v0.1.2   First official release for Grunt 0.4.0.
  * 2013-01-18   v0.1.2rc6   Updating grunt/gruntplugin dependencies to rc6. Changing in-development grunt/gruntplugin dependency versions from tilde version ranges to specific versions.
@@ -272,4 +276,4 @@ runt.initConfig({
 
 Task submitted by ["Cowboy" Ben Alman](http://benalman.com/)
 
-*This file was generated on Thu Apr 25 2013 20:22:44.*
+*This file was generated on Sun Apr 28 2013 09:28:25.*

--- a/docs/concat-examples.md
+++ b/docs/concat-examples.md
@@ -9,13 +9,13 @@ In this example, running `grunt concat:dist` (or `grunt concat` because `concat`
 grunt.initConfig({
   concat: {
     options: {
-      separator: ';'
+      separator: ';',
     },
     dist: {
       src: ['src/intro.js', 'src/project.js', 'src/outro.js'],
-      dest: 'dist/built.js'
-    }
-  }
+      dest: 'dist/built.js',
+    },
+  },
 });
 ```
 
@@ -35,13 +35,13 @@ grunt.initConfig({
     options: {
       stripBanners: true,
       banner: '/*! <%= pkg.name %> - v<%= pkg.version %> - ' +
-        '<%= grunt.template.today("yyyy-mm-dd") %> */'
+        '<%= grunt.template.today("yyyy-mm-dd") %> */',
     },
     dist: {
       src: ['src/project.js'],
-      dest: 'dist/built.js'
-    }
-  }
+      dest: 'dist/built.js',
+    },
+  },
 });
 ```
 
@@ -57,13 +57,13 @@ grunt.initConfig({
   concat: {
     basic: {
       src: ['src/main.js'],
-      dest: 'dist/basic.js'
+      dest: 'dist/basic.js',
     },
     extras: {
       src: ['src/main.js', 'src/extras.js'],
-      dest: 'dist/with_extras.js'
-    }
-  }
+      dest: 'dist/with_extras.js',
+    },
+  },
 });
 ```
 
@@ -82,10 +82,10 @@ grunt.initConfig({
     basic_and_extras: {
       files: {
         'dist/basic.js': ['src/main.js'],
-        'dist/with_extras.js': ['src/main.js', 'src/extras.js']
-      }
-    }
-  }
+        'dist/with_extras.js': ['src/main.js', 'src/extras.js'],
+      },
+    },
+  },
 });
 ```
 
@@ -102,9 +102,9 @@ grunt.initConfig({
   concat: {
     dist: {
       src: ['src/main.js'],
-      dest: 'dist/<%= pkg.name %>-<%= pkg.version %>.js'
-    }
-  }
+      dest: 'dist/<%= pkg.name %>-<%= pkg.version %>.js',
+    },
+  },
 });
 ```
 
@@ -114,24 +114,24 @@ In this more involved example, running `grunt concat` will build two separate fi
 
 For example, if the `package.json` file contained `{"name": "awesome", "version": "1.0.0"}`, the files `dist/awesome/1.0.0/basic.js` and `dist/awesome/1.0.0/with_extras.js` would be generated.
 
-```javascript
+```js
 // Project configuration.
 grunt.initConfig({
   pkg: grunt.file.readJSON('package.json'),
   dirs: {
     src: 'src/files',
-    dest: 'dist/<%= pkg.name %>/<%= pkg.version %>'
+    dest: 'dist/<%= pkg.name %>/<%= pkg.version %>',
   },
   concat: {
     basic: {
       src: ['<%= dirs.src %>/main.js'],
-      dest: '<%= dirs.dest %>/basic.js'
+      dest: '<%= dirs.dest %>/basic.js',
     },
     extras: {
       src: ['<%= dirs.src %>/main.js', '<%= dirs.src %>/extras.js'],
-      dest: '<%= dirs.dest %>/with_extras.js'
-    }
-  }
+      dest: '<%= dirs.dest %>/with_extras.js',
+    },
+  },
 });
 ```
 
@@ -157,7 +157,7 @@ See [configuring files for a task](http://gruntjs.com/configuring-tasks#files) f
 If you would like to do any custom processing before concatenating, use a custom process function:
 
 ```js
-runt.initConfig({
+grunt.initConfig({
   concat: {
     dist: {
       options: {
@@ -175,3 +175,5 @@ runt.initConfig({
   },
 });
 ```
+
+  [multi task]: https://github.com/gruntjs/grunt/wiki/grunt.task#grunttaskregistermultitask-

--- a/docs/concat-options.md
+++ b/docs/concat-options.md
@@ -36,10 +36,10 @@ Strip JavaScript banner comments from source files.
   * `line` - If true, any contiguous _leading_ `//` line comments are stripped.
 
 ## process
-Type: `Boolean` `Object`
+Type: `Boolean` `Object` `Function`
 Default: `false`
 
-Process source files as [templates][] before concatenating.
+Process source files before concatenating, either as [templates][] or with a custom function.
 
 * `false` - No processing will occur.
 * `true` - Process source files using [grunt.template.process][] defaults.
@@ -49,4 +49,4 @@ Process source files as [templates][] before concatenating.
 _(Default processing options are explained in the [grunt.template.process][] documentation)_
 
   [templates]: https://github.com/gruntjs/grunt/wiki/grunt.template
-  [grunt.template.process]: https://github.com/gruntjs/grunt/wiki/grunt.template#wiki-grunt-template-process
+  [grunt.template.process]: https://github.com/gruntjs/grunt/wiki/grunt.template#grunttemplateprocess

--- a/docs/concat-overview.md
+++ b/docs/concat-overview.md
@@ -1,1 +1,1 @@
-Task targets, files and options may be specified according to the grunt [Configuring tasks](http://gruntjs.com/configuring-tasks) guide.
+Task targets, files and options may be specified according to the Grunt [Configuring tasks](http://gruntjs.com/configuring-tasks) guide.


### PR DESCRIPTION
Just some documentation fixes.
