### PR TITLE
Removed all trailing commas from README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,13 @@ In this example, running `grunt concat:dist` (or `grunt concat` because `concat`
 grunt.initConfig({
   concat: {
     options: {
-      separator: ';',
+      separator: ';'
     },
     dist: {
       src: ['src/intro.js', 'src/project.js', 'src/outro.js'],
-      dest: 'dist/built.js',
-    },
-  },
+      dest: 'dist/built.js'
+    }
+  }
 });
 ```
 
@@ -121,9 +121,9 @@ grunt.initConfig({
     },
     dist: {
       src: ['src/project.js'],
-      dest: 'dist/built.js',
-    },
-  },
+      dest: 'dist/built.js'
+    }
+  }
 });
 ```
 
@@ -139,13 +139,13 @@ grunt.initConfig({
   concat: {
     basic: {
       src: ['src/main.js'],
-      dest: 'dist/basic.js',
+      dest: 'dist/basic.js'
     },
     extras: {
       src: ['src/main.js', 'src/extras.js'],
-      dest: 'dist/with_extras.js',
-    },
-  },
+      dest: 'dist/with_extras.js'
+    }
+  }
 });
 ```
 
@@ -164,10 +164,10 @@ grunt.initConfig({
     basic_and_extras: {
       files: {
         'dist/basic.js': ['src/main.js'],
-        'dist/with_extras.js': ['src/main.js', 'src/extras.js'],
-      },
-    },
-  },
+        'dist/with_extras.js': ['src/main.js', 'src/extras.js']
+      }
+    }
+  }
 });
 ```
 
@@ -184,9 +184,9 @@ grunt.initConfig({
   concat: {
     dist: {
       src: ['src/main.js'],
-      dest: 'dist/<%= pkg.name %>-<%= pkg.version %>.js',
-    },
-  },
+      dest: 'dist/<%= pkg.name %>-<%= pkg.version %>.js'
+    }
+  }
 });
 ```
 
@@ -202,18 +202,18 @@ grunt.initConfig({
   pkg: grunt.file.readJSON('package.json'),
   dirs: {
     src: 'src/files',
-    dest: 'dist/<%= pkg.name %>/<%= pkg.version %>',
+    dest: 'dist/<%= pkg.name %>/<%= pkg.version %>'
   },
   concat: {
     basic: {
       src: ['<%= dirs.src %>/main.js'],
-      dest: '<%= dirs.dest %>/basic.js',
+      dest: '<%= dirs.dest %>/basic.js'
     },
     extras: {
       src: ['<%= dirs.src %>/main.js', '<%= dirs.src %>/extras.js'],
-      dest: '<%= dirs.dest %>/with_extras.js',
-    },
-  },
+      dest: '<%= dirs.dest %>/with_extras.js'
+    }
+  }
 });
 ```
 
@@ -226,9 +226,9 @@ grunt.initConfig({
     missing: {
       src: ['src/invalid_or_missing_file'],
       dest: 'compiled.js',
-      nonull: true,
-    },
-  },
+      nonull: true
+    }
+  }
 });
 ```
 
@@ -248,13 +248,13 @@ grunt.initConfig({
         process: function(src, filepath) {
           return '// Source: ' + filepath + '\n' +
             src.replace(/(^|\n)[ \t]*('use strict'|"use strict");?\s*/g, '$1');
-        },
+        }
       },
       files: {
         'dist/built.js': ['src/project.js'],
-      },
-    },
-  },
+      }
+    }
+  }
 });
 ```
 


### PR DESCRIPTION
Hi. I noticed all of the examples had trailing commas. I thought I would quickly fix that. Take it if you want.
