### PR TITLE
If an encoding is specified, overwrite grunt.file.defaultEncoding.

### DIFF
--- a/tasks/concat.js
+++ b/tasks/concat.js
@@ -20,7 +20,8 @@ module.exports = function(grunt) {
       banner: '',
       footer: '',
       stripBanners: false,
-      process: false
+      process: false,
+      encoding: grunt.file.defaultEncoding
     });
 
     // Normalize boolean options that accept options objects.
@@ -44,7 +45,7 @@ module.exports = function(grunt) {
         }
       }).map(function(filepath) {
         // Read file source.
-        var src = grunt.file.read(filepath);
+        var src = grunt.file.read(filepath, { encoding: options.encoding });
         // Process files as templates if requested.
         if (typeof options.process === 'function') {
           src = options.process(src, filepath);
@@ -57,9 +58,9 @@ module.exports = function(grunt) {
         }
         return src;
       }).join(options.separator) + footer;
-
+        
       // Write the destination file.
-      grunt.file.write(f.dest, src);
+      grunt.file.write(f.dest, src, { encoding: options.encoding });
 
       // Print a success message.
       grunt.log.writeln('File "' + f.dest + '" created.');


### PR DESCRIPTION
``` javascript
/*global module:false*/
module.exports = function (grunt) {
    grunt.file.defaultEncoding = 'gbk';
    grunt.initConfig({
        concat: {
            'all': {
                options: {
                    encoding: 'utf-8'
                },
                files: [
                    {
                        src: [
                            'resource/js/jquery-ui-1.9.2.custom.js',
                            'resource/js/jquery.cookie.js',
                            'resource/js/jquery.clickoutside.js',
                            'resource/js/jquery.bgiframe.js'
                        ],
                        dest: '../build/resource/js/main.js'
                    }
                ]
            }
        }
    });
};
```
