### PR TITLE
Improved stripBanners functionality

### DIFF
--- a/tasks/lib/comment.js
+++ b/tasks/lib/comment.js
@@ -17,7 +17,7 @@ exports.init = function(/*grunt*/) {
     var m = [];
     if (options.line) {
       // Strip // ... leading banners.
-      m.push('(?:.*\\/\\/.*\\r?\\n)*\\s*');
+      src = src.replace(/(?:.*\/\/.*\r?\n)\s*/g, '');
     }
     if (options.block) {
       // Strips all /* ... */ block comment banners.
@@ -26,7 +26,7 @@ exports.init = function(/*grunt*/) {
       // Strips only /* ... */ block comment banners, excluding /*! ... */.
       m.push('\\/\\*[^!][\\s\\S]*?\\*\\/');
     }
-    var re = new RegExp('^\\s*(?:' + m.join('|') + ')\\s*', '');
+    var re = new RegExp('\\s*?(?:' + m.join('|') + ')\\s*?', 'g');
     return src.replace(re, '');
   };
 


### PR DESCRIPTION
Line and block comments should be removed with these fixes.

Line comment removing is really slow on large files, hopefully someone finds a solution here.
Also the line comment regex is from #43 
I moved the line comment removing away from the array to a separate regex so that the global flag would not mess up the file. Some funky results otherwise.
