### PR TITLE
Binary concatenation

### DIFF
--- a/tasks/concat.js
+++ b/tasks/concat.js
@@ -21,6 +21,7 @@ module.exports = function(grunt) {
     var options = this.options({
       separator: grunt.util.linefeed,
       banner: '',
+      binary: false,
       footer: '',
       stripBanners: false,
       process: false


### PR DESCRIPTION
Binary concatenation is currently broken; this PR adds a binary option and uses concatenated buffers instead of strings when used.

See: https://github.com/gruntjs/grunt-contrib-concat/issues/80
