### PR TITLE
Bumps chalk to 0.5.x.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "chalk": "~0.4.0"
+    "chalk": "~0.5.0"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.10.0",


### PR DESCRIPTION
This version contains, amongst other things, a speed improvement larger than a factor fifty. Using this version may increase logging throughput.
