### PR TITLE
Async sourcemap generator

### DIFF
--- a/tasks/concat.js
+++ b/tasks/concat.js
@@ -25,7 +25,8 @@ module.exports = function(grunt) {
       process: false,
       sourceMap: false,
       sourceMapName: undefined,
-      sourceMapStyle: 'embed'
+      sourceMapStyle: 'embed',
+      asyncSourceMap: false
     });
 
     // Normalize boolean options that accept options objects.
@@ -102,7 +103,15 @@ module.exports = function(grunt) {
 
       if (sourceMapHelper) {
         sourceMapHelper.add(footer);
-        sourceMapHelper.write();
+
+        if (options.asyncSourceMap) {
+          setTimeout(function () {
+            sourceMapHelper.write();
+          }, 0);
+        } else {
+          sourceMapHelper.write();
+        }
+
         // Add sourceMappingURL to the end.
         src += sourceMapHelper.url();
       }


### PR DESCRIPTION
Recently at my workplace we changed our development process.
Now, on every save, we need all the code to be bundled, this means that on every save we expect the sourcemap to be generated again. 
With our current codebase this takes ~1.94s (and soon we're gonna need to create bundles for specific devices, so we expect an approximate wait of more than ~4.0s).

During development we don't need the sourcemap to be immediately available, so we thought that it would be nice to have the option to have grunt-contrib-concat create it asynchronously.

I think that this functionality could be useful also for someone else, therefore the pull request.
