### PR TITLE
added new option: skipWhenSourceEmpty

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -151,6 +151,29 @@ module.exports = function(grunt) {
           ]
         }
       },
+      
+      skipWhenSourceEmpty_flagNotSet: {
+        options: {
+          skipWhenSourceEmpty: false
+        },
+        files: {
+          'tmp/skipWhenSourceEmpty_flagNotSet.css': [
+            'test/thisfiledonotexist.ext'
+          ]
+        }
+      },
+      
+      skipWhenSourceEmpty_flagSet: {
+        options: {
+          skipWhenSourceEmpty: true
+        },
+        files: {
+          'tmp/skipWhenSourceEmpty_flagSet.css': [
+            'test/thisfiledonotexist.ext'
+          ]
+        }
+      },
+      
     },
 
     // Unit tests.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ Default: `embed`
 
 Determines the type of source map that is generated. The default value, `embed`, places the content of the sources directly into the map. `link` will reference the original sources in the map as links. `inline` will store the entire map as a data URI in the destination file.
 
+#### skipWhenSourceEmpty
+Type: `Boolean`
+Default: `false`
+
+Set to true to skip writing destination file when no source files are specified, or no source files could be matched.
+
 ### Usage Examples
 
 #### Concatenating with a custom separator

--- a/tasks/concat.js
+++ b/tasks/concat.js
@@ -25,7 +25,8 @@ module.exports = function(grunt) {
       process: false,
       sourceMap: false,
       sourceMapName: undefined,
-      sourceMapStyle: 'embed'
+      sourceMapStyle: 'embed',
+      skipWhenSourceEmpty: false
     });
 
     // Normalize boolean options that accept options objects.
@@ -58,6 +59,11 @@ module.exports = function(grunt) {
 
     // Iterate over all src-dest file pairs.
     this.files.forEach(function(f) {
+    
+      // This will keep count on files matched for concat
+      // (since 'this.files' can be wildcard-matched, 'filesMatched' can be either more or less than 'this.files')
+      var filesMatched = 0;
+    
       // Initialize source map objects.
       var sourceMapHelper;
       if (sourceMap) {
@@ -78,6 +84,8 @@ module.exports = function(grunt) {
         if (grunt.file.isDir(filepath)) {
           return;
         }
+        // Increase files matched count
+        filesMatched++;
         // Read file source.
         var src = grunt.file.read(filepath);
         // Process files as templates if requested.
@@ -99,6 +107,12 @@ module.exports = function(grunt) {
         }
         return src;
       }).join(options.separator) + footer;
+
+      if(options.skipWhenSourceEmpty===true && filesMatched===0) {
+          // Do not create file (or sourcemap) if no source files have been concatenated
+          grunt.log.writeln('File ' + chalk.yellow(f.dest) + ' skipped, source empty.');
+          return;
+      }
 
       if (sourceMapHelper) {
         sourceMapHelper.add(footer);

--- a/test/concat_test.js
+++ b/test/concat_test.js
@@ -106,5 +106,15 @@ exports.concat = {
     test.equal(actual, expected, 'should output the css map.');
 
     test.done();
+  },
+  skipWhenSourceEmpty_flagNotSet: function(test) {
+    test.expect(1);
+    test.ok(grunt.file.exists('tmp/skipWhenSourceEmpty_flagNotSet.css'), 'file should exist');
+    test.done();
+  },
+  skipWhenSourceEmpty_flagSet: function(test) {
+    test.expect(1);
+    test.ok(!grunt.file.exists('tmp/skipWhenSourceEmpty_flagSet.css'), 'file should not exist');
+    test.done();
   }
 };


### PR DESCRIPTION
With this boolean flag you can opt out of writing files that contain no source files.

Sometimes a pattern do not match any files, and in those cases, you can opt out of having an empty file written to destination. This will also work when no source file/pattern is specified at all.
