### PR TITLE
Removed trailing comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,13 +109,13 @@ In this example, running `grunt concat:dist` (or `grunt concat` because `concat`
 grunt.initConfig({
   concat: {
     options: {
-      separator: ';',
+      separator: ';'
     },
     dist: {
       src: ['src/intro.js', 'src/project.js', 'src/outro.js'],
-      dest: 'dist/built.js',
-    },
-  },
+      dest: 'dist/built.js'
+    }
+  }
 });
 ```
 
@@ -135,13 +135,13 @@ grunt.initConfig({
     options: {
       stripBanners: true,
       banner: '/*! <%= pkg.name %> - v<%= pkg.version %> - ' +
-        '<%= grunt.template.today("yyyy-mm-dd") %> */',
+        '<%= grunt.template.today("yyyy-mm-dd") %> */'
     },
     dist: {
       src: ['src/project.js'],
-      dest: 'dist/built.js',
-    },
-  },
+      dest: 'dist/built.js'
+    }
+  }
 });
 ```
 
@@ -157,13 +157,13 @@ grunt.initConfig({
   concat: {
     basic: {
       src: ['src/main.js'],
-      dest: 'dist/basic.js',
+      dest: 'dist/basic.js'
     },
     extras: {
       src: ['src/main.js', 'src/extras.js'],
-      dest: 'dist/with_extras.js',
-    },
-  },
+      dest: 'dist/with_extras.js'
+    }
+  }
 });
 ```
 
@@ -182,10 +182,10 @@ grunt.initConfig({
     basic_and_extras: {
       files: {
         'dist/basic.js': ['src/main.js'],
-        'dist/with_extras.js': ['src/main.js', 'src/extras.js'],
-      },
-    },
-  },
+        'dist/with_extras.js': ['src/main.js', 'src/extras.js']
+      }
+    }
+  }
 });
 ```
 
@@ -202,9 +202,9 @@ grunt.initConfig({
   concat: {
     dist: {
       src: ['src/main.js'],
-      dest: 'dist/<%= pkg.name %>-<%= pkg.version %>.js',
-    },
-  },
+      dest: 'dist/<%= pkg.name %>-<%= pkg.version %>.js'
+    }
+  }
 });
 ```
 
@@ -220,18 +220,18 @@ grunt.initConfig({
   pkg: grunt.file.readJSON('package.json'),
   dirs: {
     src: 'src/files',
-    dest: 'dist/<%= pkg.name %>/<%= pkg.version %>',
+    dest: 'dist/<%= pkg.name %>/<%= pkg.version %>'
   },
   concat: {
     basic: {
       src: ['<%= dirs.src %>/main.js'],
-      dest: '<%= dirs.dest %>/basic.js',
+      dest: '<%= dirs.dest %>/basic.js'
     },
     extras: {
       src: ['<%= dirs.src %>/main.js', '<%= dirs.src %>/extras.js'],
-      dest: '<%= dirs.dest %>/with_extras.js',
-    },
-  },
+      dest: '<%= dirs.dest %>/with_extras.js'
+    }
+  }
 });
 ```
 
@@ -244,9 +244,9 @@ grunt.initConfig({
     missing: {
       src: ['src/invalid_or_missing_file'],
       dest: 'compiled.js',
-      nonull: true,
-    },
-  },
+      nonull: true
+    }
+  }
 });
 ```
 
@@ -266,13 +266,13 @@ grunt.initConfig({
         process: function(src, filepath) {
           return '// Source: ' + filepath + '\n' +
             src.replace(/(^|\n)[ \t]*('use strict'|"use strict");?\s*/g, '$1');
-        },
+        }
       },
       files: {
-        'dist/built.js': ['src/project.js'],
-      },
-    },
-  },
+        'dist/built.js': ['src/project.js']
+      }
+    }
+  }
 });
 ```
 


### PR DESCRIPTION
Removed trailing commas in readme to comform with javascript convention. This improves readability for most users who isn't used to seeing trailing commas.