### PR TITLE
Fix path issues with source maps

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+/test/fixtures/* text eol=lf

--- a/tasks/lib/sourcemap.js
+++ b/tasks/lib/sourcemap.js
@@ -95,7 +95,8 @@ exports.init = function(grunt) {
   // prior sourcemap and return src with sourceMappingURL removed.
   SourceMapConcatHelper.prototype.addlines = function(src, filename) {
     var relativeFilename = path.relative(path.dirname(this.dest), filename);
-
+    // sourceMap path references are URLs, so ensure forward slashes are used for paths passed to sourcemap library
+    relativeFilename = relativeFilename.replace(/\\/g, '/');
     var node;
     if (
       /\/\/[@#]\s+sourceMappingURL=(.+)/.test(src) ||
@@ -121,6 +122,8 @@ exports.init = function(grunt) {
       // Consider the relative path from source files to new sourcemap.
       var sourcePathToSourceMapPath =
         path.relative(path.dirname(this.dest), path.dirname(sourceMapPath));
+      // sourceMap path references are URLs, so ensure forward slashes are used for paths passed to sourcemap library
+      sourcePathToSourceMapPath = sourcePathToSourceMapPath.replace(/\\/g, '/');
       // Store the sourceMap so that it may later be consumed.
       this.maps.push([
         sourceMapConsumer, relativeFilename, sourcePathToSourceMapPath
@@ -170,8 +173,11 @@ exports.init = function(grunt) {
 
   // Return a string for inline use or write the source map to disk.
   SourceMapConcatHelper.prototype._write = function() {
+    // ensure we're using forward slashes, because these are URLs
+    var file = path.relative(path.dirname(this.dest), this.files.dest);
+    file = file.replace(/\\/g, '/');
     var code_map = this.node.toStringWithSourceMap({
-      file: path.relative(path.dirname(this.dest), this.files.dest)
+      file: file
     });
     // Consume the new sourcemap.
     var generator = SourceMapGenerator.fromSourceMap(


### PR DESCRIPTION
On Windows, node's path api returns backslashes for path separators.

Because the source-map library expects forward slashes in all cases, their relative path logic (specifically their "normalize" function) gives incorrect results when passing in backslash.  The mozilla/source-map library won't change this, because they are actually expecting URLs as input - see https://github.com/mozilla/source-map/issues/91#issuecomment-34845169.

This fix is similar to the one made for grunt-contrib-uglify: https://github.com/gruntjs/grunt-contrib-uglify/pull/175.

Fixes #95.
