### PR TITLE
Docs: use `\n;` as an example for concatinating JavaScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Task targets, files and options may be specified according to the Grunt [Configu
 Type: `String`
 Default: `grunt.util.linefeed`
 
-Concatenated files will be joined on this string. If you're post-processing concatenated JavaScript files with a minifier, you may need to use a semicolon `';'` as the separator.
+Concatenated files will be joined on this string. If you're post-processing concatenated JavaScript files with a minifier, you may need to use a semicolon `';\n'` as the separator.
 
 #### banner
 Type: `String`

--- a/docs/concat-options.md
+++ b/docs/concat-options.md
@@ -4,7 +4,7 @@
 Type: `String`
 Default: `grunt.util.linefeed`
 
-Concatenated files will be joined on this string. If you're post-processing concatenated JavaScript files with a minifier, you may need to use a semicolon `';'` as the separator.
+Concatenated files will be joined on this string. If you're post-processing concatenated JavaScript files with a minifier, you may need to use a semicolon `';\n'` as the separator.
 
 ## banner
 Type: `String`


### PR DESCRIPTION
Fix #120