### PR TITLE
Updated readme to remove extra comma typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ grunt.initConfig({
     dist: {
       src: ['src/intro.js', 'src/project.js', 'src/outro.js'],
       dest: 'dist/built.js',
-    },
-  },
+    }
+  }
 });
 ```
 
@@ -140,8 +140,8 @@ grunt.initConfig({
     dist: {
       src: ['src/project.js'],
       dest: 'dist/built.js',
-    },
-  },
+    }
+  }
 });
 ```
 
@@ -162,8 +162,8 @@ grunt.initConfig({
     extras: {
       src: ['src/main.js', 'src/extras.js'],
       dest: 'dist/with_extras.js',
-    },
-  },
+    }
+  }
 });
 ```
 
@@ -183,9 +183,9 @@ grunt.initConfig({
       files: {
         'dist/basic.js': ['src/main.js'],
         'dist/with_extras.js': ['src/main.js', 'src/extras.js'],
-      },
-    },
-  },
+      }
+    }
+  }
 });
 ```
 
@@ -203,8 +203,8 @@ grunt.initConfig({
     dist: {
       src: ['src/main.js'],
       dest: 'dist/<%= pkg.name %>-<%= pkg.version %>.js',
-    },
-  },
+    }
+  }
 });
 ```
 
@@ -230,8 +230,8 @@ grunt.initConfig({
     extras: {
       src: ['<%= dirs.src %>/main.js', '<%= dirs.src %>/extras.js'],
       dest: '<%= dirs.dest %>/with_extras.js',
-    },
-  },
+    }
+  }
 });
 ```
 
@@ -245,8 +245,8 @@ grunt.initConfig({
       src: ['src/invalid_or_missing_file'],
       dest: 'compiled.js',
       nonull: true,
-    },
-  },
+    }
+  }
 });
 ```
 
@@ -266,13 +266,13 @@ grunt.initConfig({
         process: function(src, filepath) {
           return '// Source: ' + filepath + '\n' +
             src.replace(/(^|\n)[ \t]*('use strict'|"use strict");?\s*/g, '$1');
-        },
+        }
       },
       files: {
         'dist/built.js': ['src/project.js'],
-      },
-    },
-  },
+      }
+    }
+  }
 });
 ```
 


### PR DESCRIPTION
Removed extra commas in the readme usage examples. The syntax now matches standard JavaScript syntax and has improved clarity for readers of the readme.

![image](https://cloud.githubusercontent.com/assets/9893865/8097300/8068e820-0f95-11e5-9286-71d9bfb01b6e.png)

![image](https://cloud.githubusercontent.com/assets/9893865/8097307/8f799986-0f95-11e5-903d-2306c80f1df2.png)

![image](https://cloud.githubusercontent.com/assets/9893865/8097312/984436a2-0f95-11e5-9dfe-07b62f941486.png)
