### PR TITLE
Update sourcemap.js

### DIFF
--- a/tasks/lib/sourcemap.js
+++ b/tasks/lib/sourcemap.js
@@ -109,10 +109,10 @@ exports.init = function(grunt) {
 
       var sourceContent;
       // Browserify, as an example, stores a datauri at sourceMappingURL.
-      if (/data:application\/json;base64,([^\s]+)/.test(sourceMapFile)) {
+      if (/data:application\/json;(charset:utf-8;)?base64,([^\s]+)/.test(sourceMapFile)) {
         // Set sourceMapPath to the file that the map is inlined.
         sourceMapPath = filename;
-        sourceContent = new Buffer(RegExp.$1, 'base64').toString();
+        sourceContent = new Buffer(RegExp.$2, 'base64').toString();
       } else {
         // If sourceMapPath is relative, expand relative to the file
         // refering to it.


### PR DESCRIPTION
browserify with debug:true stores a sourcemap at the end of the file as a datauri

sometimes the datauri is prefixed with "data:application/json;base64," and sometimes with `data:application/json;charset:utf-8;base64,`

changed the regexp at line 112 to account for the difference