### PR TITLE
Add sourceMapExclude option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -127,6 +127,19 @@ module.exports = function(grunt) {
           ]
         }
       },
+      sourcemap4_options: {
+        options: {
+          sourceMap: true,
+          sourceMapName: 'tmp/sourcemap4_exclude_map.map',
+          sourceMapExclude: ['test/fixtures/file1']
+        },
+        files: {
+          'tmp/sourcemap4_exclude': [
+            'test/fixtures/file1',
+            'test/fixtures/file2'
+          ]
+        }
+      },
       sourcemap_js: {
         options: {
           banner: '/*\nJS Banner\n*/\n',

--- a/tasks/concat.js
+++ b/tasks/concat.js
@@ -25,7 +25,8 @@ module.exports = function(grunt) {
       process: false,
       sourceMap: false,
       sourceMapName: undefined,
-      sourceMapStyle: 'embed'
+      sourceMapStyle: 'embed',
+      sourceMapExclude: undefined
     });
 
     // Normalize boolean options that accept options objects.
@@ -63,10 +64,16 @@ module.exports = function(grunt) {
     // Iterate over all src-dest file pairs.
     this.files.forEach(function(f) {
       // Initialize source map objects.
-      var sourceMapHelper;
+      var sourceMapHelper, sourceMapExclude;
       if (sourceMap) {
         sourceMapHelper = sourcemap.helper(f, options);
         sourceMapHelper.add(banner);
+        sourceMapExclude = {};
+        if (options.sourceMapExclude) {
+          grunt.file.match(options.sourceMapExclude, f.src).forEach(function(filepath) {
+            sourceMapExclude[filepath] = true;
+          });
+        }
       }
 
       // Concat banner + specified files + footer.
@@ -95,7 +102,11 @@ module.exports = function(grunt) {
         }
         // Add the lines of this file to our map.
         if (sourceMapHelper) {
-          src = sourceMapHelper.addlines(src, filepath);
+          if (sourceMapExclude[filepath]) {
+            sourceMapHelper.add(src);
+          } else {
+            src = sourceMapHelper.addlines(src, filepath);
+          }
           if (i < f.src.length - 1) {
             sourceMapHelper.add(options.separator);
           }

--- a/test/concat_test.js
+++ b/test/concat_test.js
@@ -83,7 +83,7 @@ exports.concat = {
     test.done();
   },
   sourcemap_options: function(test) {
-    test.expect(5);
+    test.expect(6);
 
     var actual = getNormalizedFile('tmp/sourcemap_inline');
     var expected = getNormalizedFile('test/expected/sourcemap_inline');
@@ -95,6 +95,10 @@ exports.concat = {
 
     actual = getNormalizedFile('tmp/sourcemap3_embed_map.map');
     expected = getNormalizedFile('test/expected/sourcemap3_embed.map');
+    test.equal(actual, expected, 'should output the constructed map.');
+
+    actual = getNormalizedFile('tmp/sourcemap4_exclude_map.map');
+    expected = getNormalizedFile('test/expected/sourcemap4_exclude.map');
     test.equal(actual, expected, 'should output the constructed map.');
 
     actual = getNormalizedFile('tmp/sourcemap_js.js.map');

--- a/test/expected/sourcemap4_exclude.map
+++ b/test/expected/sourcemap4_exclude.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["../test/fixtures/file2"],"names":[],"mappings":";AAAA","file":"sourcemap4_exclude","sourcesContent":["file2"]}


### PR DESCRIPTION
It allows to exclude certain files (globs) from the source map generation. Can be useful to make `grunt concat` faster. E.g. if you concatenate together your own source files and big third-party libraries, the chances are quite high you don't need the source maps for the libraries.
