### PR TITLE
Add new option log

### DIFF
--- a/tasks/concat.js
+++ b/tasks/concat.js
@@ -21,6 +21,7 @@ module.exports = function(grunt) {
       separator: grunt.util.linefeed,
       banner: '',
       footer: '',
+      log: true,
       stripBanners: false,
       process: false,
       sourceMap: false,
@@ -114,7 +115,12 @@ module.exports = function(grunt) {
       grunt.file.write(f.dest, src);
 
       // Print a success message.
-      grunt.verbose.write('File ' + chalk.cyan(f.dest) + ' created.');
+      if (options.log === true) {
+        grunt.log.writeln('File ' + chalk.cyan(f.dest) + ' created.');
+      } else {
+        grunt.verbose.write('File ' + chalk.cyan(f.dest) + ' created.');
+      }
+      }
     });
   });
 


### PR DESCRIPTION
The default is set as true.

This is so a user has a choice between verbose or just seeing that the file has been created and dosent't want to see all the information.

Follows up https://github.com/gruntjs/grunt-contrib-concat/pull/145/files

And fixes https://github.com/gruntjs/grunt-contrib-concat/issues/153