### PR TITLE
Support for 'nonull': 'error'

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -155,7 +155,7 @@ module.exports = function(grunt) {
 
     // Unit tests.
     nodeunit: {
-      tests: ['test/concat_test.js']
+      tests: ['test/*_test.js']
     }
 
   });

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -194,7 +194,7 @@ module.exports = function(grunt) {
         if (err && code === 1 && result.stdout.indexOf('Fatal error: Source file "invalid_file/should_warn/but_not_fail" not found') >= 0) {
           grunt.file.write('tmp/error_handling', 'pass');
         } else {
-          // return grunt.fatal('Expected fatal error, but none was reported.');
+          grunt.file.write('tmp/error_handling', 'fail');
         }
 
           return done();

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -155,7 +155,7 @@ module.exports = function(grunt) {
 
     // Unit tests.
     nodeunit: {
-      tests: ['test/*_test.js']
+      tests: ['test/concat_test.js']
     }
 
   });
@@ -171,7 +171,37 @@ module.exports = function(grunt) {
 
   // Whenever the "test" task is run, first clean the "tmp" dir, then run this
   // plugin's task(s), then test the result.
-  grunt.registerTask('test', ['jshint', 'clean', 'concat', 'nodeunit']);
+  grunt.registerTask('test', ['jshint', 'clean', 'concat', 'exec-concat-throw', 'nodeunit']);
+
+  grunt.registerTask('concat-throw', function() {
+
+      var conf = grunt.config('concat');
+      conf.handling_invalid_files.nonull = 'error';
+      grunt.config('concat', conf);
+      grunt.task.run(['concat:handling_invalid_files']);
+
+  });
+
+  grunt.registerTask('exec-concat-throw', function() {
+
+      var done = this.async();
+
+      grunt.util.spawn({
+        'cmd': 'grunt',
+        'args': ['concat-throw']
+      }, function(err, result, code) {
+
+        if (err && code === 1 && result.stdout.indexOf('Fatal error: Source file "invalid_file/should_warn/but_not_fail" not found') >= 0) {
+          grunt.file.write('tmp/error_handling', 'pass');
+        } else {
+          // return grunt.fatal('Expected fatal error, but none was reported.');
+        }
+
+          return done();
+
+      });
+
+  });
 
   // By default, lint and run all tests.
   grunt.registerTask('default', ['test', 'build-contrib']);

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ Task targets, files and options may be specified according to the Grunt [Configu
 ### Options
 
 #### separator
-Type: `String`  
+Type: `String`
 Default: `grunt.util.linefeed`
 
 Concatenated files will be joined on this string. If you're post-processing concatenated JavaScript files with a minifier, you may need to use a semicolon `';\n'` as the separator.
 
 #### banner
-Type: `String`  
+Type: `String`
 Default: `''`
 
 This string will be prepended to the beginning of the concatenated output. It is processed using [grunt.template.process][], using the default options.
@@ -43,7 +43,7 @@ This string will be prepended to the beginning of the concatenated output. It is
 _(Default processing options are explained in the [grunt.template.process][] documentation)_
 
 #### footer
-Type: `String`  
+Type: `String`
 Default: `''`
 
 This string will be appended to the end of the concatenated output. It is processed using [grunt.template.process][], using the default options.
@@ -51,7 +51,7 @@ This string will be appended to the end of the concatenated output. It is proces
 _(Default processing options are explained in the [grunt.template.process][] documentation)_
 
 #### stripBanners
-Type: `Boolean` `Object`  
+Type: `Boolean` `Object`
 Default: `false`
 
 Strip JavaScript banner comments from source files.
@@ -64,7 +64,7 @@ Strip JavaScript banner comments from source files.
   * `line` - If true, any contiguous _leading_ `//` line comments are stripped.
 
 #### process
-Type: `Boolean` `Object` `Function`  
+Type: `Boolean` `Object` `Function`
 Default: `false`
 
 Process source files before concatenating, either as [templates][] or with a custom function.
@@ -80,19 +80,19 @@ _(Default processing options are explained in the [grunt.template.process][] doc
   [grunt.template.process]: https://github.com/gruntjs/grunt-docs/blob/master/grunt.template.md#grunttemplateprocess
 
 #### sourceMap
-Type: `Boolean`  
+Type: `Boolean`
 Default: `false`
 
 Set to true to create a source map. The source map will be created alongside the destination file, and share the same file name with the `.map` extension appended to it.
 
 #### sourceMapName
-Type: `String` `Function`  
+Type: `String` `Function`
 Default: `undefined`
 
 To customize the name or location of the generated source map, pass a string to indicate where to write the source map to. If a function is provided, the concat destination is passed as the argument and the return value will be used as the file name.
 
 #### sourceMapStyle
-Type: `String`  
+Type: `String`
 Default: `embed`
 
 Determines the type of source map that is generated. The default value, `embed`, places the content of the sources directly into the map. `link` will reference the original sources in the map as links. `inline` will store the entire map as a data URI in the destination file.
@@ -234,7 +234,7 @@ grunt.initConfig({
 });
 ```
 
-#### Invalid or Missing Files Warning
+#### Invalid or Missing Files: Warnings and Errors
 If you would like the `concat` task to warn if a given file is missing or invalid be sure to set `nonull` to `true`:
 
 ```js
@@ -244,6 +244,20 @@ grunt.initConfig({
       src: ['src/invalid_or_missing_file'],
       dest: 'compiled.js',
       nonull: true,
+    },
+  },
+});
+```
+
+Alternatively, to have Grunt throw a fatal error if a given file is missing or invalid you can set `nonull` to `error`:
+
+```js
+grunt.initConfig({
+  concat: {
+    missing: {
+      src: ['src/invalid_or_missing_file'],
+      dest: 'compiled.js',
+      nonull: 'error',
     },
   },
 });

--- a/tasks/concat.js
+++ b/tasks/concat.js
@@ -62,6 +62,7 @@ module.exports = function(grunt) {
 
     // Iterate over all src-dest file pairs.
     this.files.forEach(function(f) {
+
       // Initialize source map objects.
       var sourceMapHelper;
       if (sourceMap) {
@@ -73,7 +74,12 @@ module.exports = function(grunt) {
       var src = banner + f.src.filter(function(filepath) {
         // Warn on and remove invalid source files (if nonull was set).
         if (!grunt.file.exists(filepath)) {
-          grunt.log.warn('Source file "' + filepath + '" not found.');
+          var err = 'Source file "' + filepath + '" not found.';
+          if (f.nonull === 'error') {
+            grunt.fatal(new Error(err));
+          } else {
+            grunt.log.warn(err);
+          }
           return false;
         }
         return true;

--- a/test/concat_test.js
+++ b/test/concat_test.js
@@ -106,5 +106,10 @@ exports.concat = {
     test.equal(actual, expected, 'should output the css map.');
 
     test.done();
+  },
+  error_handling: function(test) {
+    var actual = getNormalizedFile('tmp/error_handling');
+    test.equal(actual, 'pass', 'An error should be thrown when "nonull": "error" is set');
+    test.done();
   }
 };


### PR DESCRIPTION
This PR is similar to the one that's been sitting [here](https://github.com/gruntjs/grunt-contrib-concat/pull/106) for nearly two(!) years. It's a simple six line change that allows users to specify that the task should throw an error via `grunt.fail.fatal()` when a missing file is encountered. It is entirely backwards-compatible. You have three options:

```
{ 'nonull': false } // Don't warn about missing files
{ 'nonull': true } // Warn about missing files
{ 'nonull': 'error' } // Throw missing files
```
