### PR TITLE
fix(sourcemap-regex): fix regex to match browserify sorucemap charset

### DIFF
--- a/tasks/lib/sourcemap.js
+++ b/tasks/lib/sourcemap.js
@@ -146,7 +146,7 @@ exports.init = function(grunt) {
 
       var sourceContent;
       // Browserify, as an example, stores a datauri at sourceMappingURL.
-      if (/data:application\/json;(charset:utf-8;)?base64,([^\s]+)/.test(sourceMapFile)) {
+      if (/data:application\/json;(charset.utf-8;)?base64,([^\s]+)/.test(sourceMapFile)) {
         // Set sourceMapPath to the file that the map is inlined.
         sourceMapPath = filename;
         sourceContent = new Buffer(RegExp.$2, 'base64').toString();


### PR DESCRIPTION
Browserify has changed the sourcemap charset to use `=` instead of `:`.
This has frequently changed, so this fix changes the regex to match a
single character `.`
For reference:
https://github.com/substack/node-browserify/blob/b2374cef35072e7690ab31a68664b0733c1b4995/changelog.markdown#1200

Fixes #130