### PR TITLE
Add "displayLog" property

### DIFF
--- a/tasks/concat.js
+++ b/tasks/concat.js
@@ -60,6 +60,8 @@ module.exports = function(grunt) {
       sourceMap = false;
     }
 
+    var outputFiles = [];
+
     // Iterate over all src-dest file pairs.
     this.files.forEach(function(f) {
       // Initialize source map objects.
@@ -114,8 +116,14 @@ module.exports = function(grunt) {
       grunt.file.write(f.dest, src);
 
       // Print a success message.
-      grunt.verbose.write('File ' + chalk.cyan(f.dest) + ' created.');
+      if (!!options.displayLog) {
+        grunt.verbose.write('File ' + chalk.cyan(f.dest) + ' created.');
+      }
+      outputFiles.push(chalk.cyan(f.dest));
     });
+
+    grunt.verbose.write(outputFiles.length + ' new files created.');
+
   });
 
 };

--- a/tasks/lib/sourcemap.js
+++ b/tasks/lib/sourcemap.js
@@ -246,7 +246,9 @@ exports.init = function(grunt) {
       this.dest,
       JSON.stringify(newSourceMap, null, '')
     );
-    grunt.verbose.writeln('Source map ' + chalk.cyan(this.dest) + ' created.');
+    if (!!this.options.displayLog) {
+      grunt.verbose.writeln('Source map ' + chalk.cyan(this.dest) + ' created.');
+    }
 
   };
 


### PR DESCRIPTION
I added a new config property: displayLog (true/false)
This is to enable/disable the log "File xxxxx created", since it can be too verbose when we have many files.
I also added a log to count the total at the end.